### PR TITLE
drag&drop => increase draged element width

### DIFF
--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -289,9 +289,9 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
 
                 draggableObj.iconEl.appendTo(draggableObj.containerEl);
 
-                draggableObj.iconWidth = draggableObj.iconEl.width() + 1;
+                draggableObj.iconWidth = draggableObj.iconEl.width() + 21;
                 draggableObj.iconHeight = draggableObj.iconEl.height();
-                draggableObj.iconWidthSmall = draggableObj.iconWidth;
+                draggableObj.iconWidthSmall = draggableObj.iconWidth - 20;
                 draggableObj.iconHeightSmall = draggableObj.iconHeight;
 
                 draggableObj.iconEl.css({


### PR DESCRIPTION
При перетаскивании элемента в компоненте drag&drop у элемента добавляются отступы и рамка (в сумме + 18px к ширине). Выделенная ширина при этом остается прежней, что приводит к http://redmine.sgdev.xyz/issues/12057#change-44890