### PR TITLE
translate loupe example, replace default link to loupe with modified one

### DIFF
--- a/common/lib/xmodule/xmodule/templates/html/zooming_image.yaml
+++ b/common/lib/xmodule/xmodule/templates/html/zooming_image.yaml
@@ -1,13 +1,15 @@
+# changed by @happyblitz http://redmine.sgdev.xyz/issues/19958
+# Here we add localization and a link to modified version of a loupe
 ---
 metadata:
     display_name: Zooming Image Tool
 data: |
       <h3 class="hd hd-2">Zooming Image Tool</h3>
-      <p>Use the Zooming Image Tool to enable learners to see details of large, complex images.</p>
-      <p>With the Zooming Image Tool, the learner can move the mouse pointer over a part of the image to enlarge it and see more detail.</p>
-      <p>To use the Zooming Image Tool, you must first add the <a href="http://files.edx.org/jquery.loupeAndLightbox.js" target="_blank">jquery.loupeAndLightbox.js JavaScript file</a> to your course.</p>
-      <p>You must also add both the regular and magnified image files to your course.</p>
-      <p>The following HTML code shows the format required to use the Zooming Image tool. For the example in this template, you must replace the values in <i>italics</i>.</p>
+      <p>Используйте инструмент Zooming Image Tool, чтобы ученики могли видеть детали больших и сложных изображений.</p>
+      <p>С помощью инструмента Zooming Image Tool ученик может навести указатель мыши на часть изображения, чтобы увеличить его и увидеть больше деталей.</p>
+      <p>Чтобы использовать инструмент Zooming Image Tool, вы должны сначала добавить в свой курс JavaScript-файл <a href="https://cdn.jsdelivr.net/gh/oleg2106/jquery.loupeAndLightbox.js@master/jquery.loupeAndLightbox.js" target="_blank">jquery.loupeAndLightbox.js JavaScript file</a>.</p>
+      <p>Вы также должны добавить в свой курс как обычные, так и увеличенные файлы изображений.</p>
+      <p>В следующем HTML-коде показан формат, необходимый для использования инструмента «Масштабирование изображения». Для примера в этом шаблоне вы должны заменить значения <i>курсивом</i>.</p>
         <pre>
         &lt;div class="zooming-image-place" style="position: relative;"&gt;
           &lt;a class="loupe" href="<i>path to the magnified version of the image</i>"&gt;
@@ -29,21 +31,21 @@ data: |
         &lt;div id="ap_listener_added"&gt;&lt;/div&gt;
         </pre>
 
-      <p>You can modify the example below for your own use.</p>
+      <p>Вы можете изменить приведенный ниже пример для собственного использования.</p>
       <ol>
-        <li>Replace the value of the link's <strong>href</strong> attribute with the path to the magnified image. Do not change the value of the class attribute.</li>
-        <li>Replace the value of the image's <strong>src</strong> attribute with the path to the image that will appear in the unit.</li>
-        <li>Replace the value of the image's <strong>alt</strong> attribute with text that both describes the image and the action or destination of clicking on the image. You <strong>must</strong> include alt text to provide an accessible label.</li>
-        <li>Replace the value of the div element's <strong>data-src</strong> attribute with the path to the jquery.loupeAndLightbox.js JavaScript file in your course.</li>
+        <li>Замените значение атрибута <strong>href</strong> ссылки на путь к увеличенному изображению. Не изменяйте значение атрибута класса.</li>
+        <li>Замените значение атрибута <strong>src</strong> изображения на путь к изображению, которое появится в блоке.</li>
+        <li>Замените значение атрибута <strong>alt</strong> изображения текстом, который описывает изображение и действие или назначение нажатия на изображение. Вы  <strong>должны</strong> включить альтернативный текст, чтобы обеспечить доступную метку.</li>
+        <li>Замените значение атрибута <strong>data-src</strong> элемента div на путь к файлу JavaScript jquery.loupeAndLightbox.js в вашем курсе.</li>
       </ol>
-      <p>The example below shows a subset of the biochemical reactions that cells carry out. </p>
-      <p>You can view the chemical structures of the molecules by clicking on them. The magnified view also lists the enzymes involved in each step.</p>
-      <p class="sr">Press spacebar to open the magnifier.</p>
+      <p>Пример ниже показывает подмножество биохимических реакций, которые клетки проводят.</p>
+      <p>Вы можете просмотреть химические структуры молекул, нажав на них. Увеличенное изображение также перечисляет ферменты, участвующие в каждом шаге.</p>
+      <p class="sr">Нажмите пробел, чтобы открыть лупу.</p>
       <div class="zooming-image-place" style="position: relative;">
         <a class="loupe" href="https://studio.edx.org/c4x/edX/DemoX/asset/pathways_detail_01.png">
             <img alt="magnify" src="https://studio.edx.org/c4x/edX/DemoX/asset/pathways_overview_01.png" />
           </a>
-        <div class="script_placeholder" data-src="https://studio.edx.org/c4x/edX/DemoX/asset/jquery.loupeAndLightbox.js" />
+        <div class="script_placeholder" data-src="https://cdn.jsdelivr.net/gh/oleg2106/jquery.loupeAndLightbox.js@master/jquery.loupeAndLightbox.js" />
       </div>
       <script type="text/javascript">// <![CDATA[
       JavascriptLoader.executeModuleScripts($('.zooming-image-place').eq(0), function() {


### PR DESCRIPTION
http://redmine.sgdev.xyz/issues/19958

Перевел текст по умолчанию для нового элемента Лупа.
Видоизменили лупу (репозиторий https://github.com/oleg2106/jquery.loupeAndLightbox.js). Ссылка для вставки на страницу:
https://cdn.jsdelivr.net/gh/oleg2106/jquery.loupeAndLightbox.js@master/jquery.loupeAndLightbox.js